### PR TITLE
1.9.1 (2016-11-11)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.9.1 (2016-11-11)
+  - bugfix: show installed modules in list if checkbox "only installed" is not active
+
 1.9.0 (2016-10-20)
   - added filter checkboxes to only show installed and/or active modules in the list
 

--- a/modules/ioly/ioly/controllers/admin/ioly_main.php
+++ b/modules/ioly/ioly/controllers/admin/ioly_main.php
@@ -12,7 +12,7 @@
  * @author   Stefan Moises <stefan@rent-a-hero.de>
  * @license  MIT License http://opensource.org/licenses/MIT
  * @link     http://getioly.com/
- * @version     1.9.0
+ * @version     1.9.1
  */
 class ioly_main extends oxAdminView
 {
@@ -225,9 +225,7 @@ class ioly_main extends oxAdminView
             $addModule = false;
             foreach ($aVersions as $packageVersion => $versionInfo) {
                 if ($this->_ioly->isInstalledInVersion($packageId, $packageVersion)) {
-                    if ($onlyInstalled) {
-                        $addModule = true;
-                    }
+                    $addModule = true;
                     if ($onlyActive) {
                         if ($this->isModuleActive($packageId, $packageVersion)) {
                             $addModule = true;

--- a/modules/ioly/ioly/metadata.php
+++ b/modules/ioly/ioly/metadata.php
@@ -30,7 +30,7 @@ $aModule = array(
         'en' => 'ioly module manager (<a href="http://getioly.com" target="_blank">getioly.com</a> / <a href="https://github.com/ioly/ioly" target="_blank">github.com/ioly/ioly</a>)',
     ),
     'thumbnail'   => 'ioly_logo.png',
-    'version'     => '1.9.0',
+    'version'     => '1.9.1',
     'author'      => 'ioly',
     'url'         => 'https://github.com/ioly/ioly',
     'email'       => 'hello@getioly.com',


### PR DESCRIPTION
  - bugfix: show installed modules in list if checkbox "only installed" is not active